### PR TITLE
Adds entrypoint to CLI because the Go docker client can't run a RUN/CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14.15.1-alpine3.12
 
 WORKDIR /usr/src/app
-COPY tsconfig.json install.sh entrypoint-dev.sh entrypoint-prod.sh index.ts ./
+COPY tsconfig.json install.sh entrypoint-dev.sh entrypoint-cli.sh entrypoint-prod.sh index.ts ./
 RUN chmod +x install.sh entrypoint-dev.sh entrypoint-prod.sh
 
 # RUN yarn cache express express-async-handler glob morgan @babel/core @babel/cli @babel/preset-env @babel/polyfill @babel/plugin-transform-runtime @babel/node nodemon

--- a/entrypoint-cli.sh
+++ b/entrypoint-cli.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+if [ -f "api/package-lock.json" ]; then
+  cp api/package*.json .
+  npm install
+  npm add express express-async-handler glob morgan
+  npm add --save-dev @types/express @types/glob @types/morgan@1.9.0 @types/node nodemon ts-node typescript
+  npm cache clean --force
+else
+  cp api/package.json api/yarn.lock . || true
+  yarn install || true
+  yarn add express express-async-handler glob morgan
+  yarn add -D @types/express @types/glob @types/morgan@1.9.0 @types/node nodemon ts-node typescript
+  yarn cache clean
+fi
+
+./node_modules/.bin/nodemon --watch 'api/**/*' --ext 'js,ts,json' --ignore 'api/**/*.spec.ts' --ignore 'api/node_modules' --exec './node_modules/.bin/ts-node' index.ts


### PR DESCRIPTION
before entrypoint